### PR TITLE
Fix sublime unicode highlighter for sublime text 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,7 @@
-# Unicode character highlighter for Sublime Text 2
+# Unicode character highlighter for Sublime Text 3
 
 This plug-in highlights characters such as non breakable space, characters that often break compilers and scripts and is almost impossible to spot in the editor.
 
 ## Installation
 
-To install this plug-in simply clone this repository into your "Packages" directory:
-
-<pre>
-cd ~/Library/Application\ Support/Sublime\ Text\ 2/Packages
-git clone https://github.com/possan/sublime_unicode_nbsp.git sublime_unicode_nbsp
-</pre>
-
+To install this plug-in use package manager.

--- a/sublime_unicode_nbsp.py
+++ b/sublime_unicode_nbsp.py
@@ -15,7 +15,7 @@ def view_is_too_big(view, max_size_setting, default_max_size=None):
     settings = view.settings()
     max_size = settings.get(max_size_setting, default_max_size)
     if max_size not in (None, False):
-        max_size = long(max_size)
+        max_size = int(max_size)
         cur_size = view.size()
         if cur_size > max_size:
             return True
@@ -127,4 +127,4 @@ class HighlightUnicodeListener(DeferedViewListener):
         #for x in view.find_all(u'^$'):
         #    regions.append(x)
         view.add_regions('HighlightUnicodeJunk', regions, color_name,
-                         sublime.DRAW_EMPTY_AS_OVERWRITE)
+                         flags=sublime.DRAW_EMPTY_AS_OVERWRITE)


### PR DESCRIPTION
It should works on sublime text 2 too, but I didn't test.
