### PR TITLE
Fix sublime_unicode_nbsp for both sublime text 2&3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ This plug-in highlights characters such as non breakable space, characters that 
 ## Installation
 
 To install this plug-in use package manager.
+
+## Customization
+
+You might want to override the following parameters within your file settings:
+
+`highlight_unicode_max_file_size`: Restrict this to a sane size in order not to DDOS your editor. Defaults to 1048576 (1 Mio).
+
+`highlight_unicode_color_name`: Change this to a valid scope name, which has to be defined within your theme. Defaults to 'invalid'.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Unicode character highlighter for Sublime Text 3
+# Unicode character highlighter for Sublime Text 2 & 3
 
 This plug-in highlights characters such as non breakable space, characters that often break compilers and scripts and is almost impossible to spot in the editor.
 

--- a/sublime_unicode_nbsp.py
+++ b/sublime_unicode_nbsp.py
@@ -126,5 +126,6 @@ class HighlightUnicodeListener(DeferedViewListener):
 
         #for x in view.find_all(u'^$'):
         #    regions.append(x)
-        view.add_regions('HighlightUnicodeJunk', regions, color_name,
-                         flags=sublime.DRAW_EMPTY_AS_OVERWRITE)
+        icon = ''
+        flags = sublime.DRAW_EMPTY_AS_OVERWRITE
+        view.add_regions('HighlightUnicodeJunk', regions, color_name, icon, flags)


### PR DESCRIPTION
c7aa39c broke compatibility with sublime text 2. This one works on
both 2 and 3.

Update README with parameters customization info
