### PR TITLE
Adds official name to installation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This plug-in highlights characters such as non breakable space, characters that 
 
 ## Installation
 
-To install this plug-in use package manager.
+To install this plug-in use package manager: `Unicode Character Highlighter`
 
 ## Customization
 


### PR DESCRIPTION
I'm always confused and catch myself searching for `sublime_unicode_nbsp` or `unicode` or `nbsp`.. This commit adds the official name, so my future-self is less confused and can concentrate more on work :P
